### PR TITLE
Issues Severity New Issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 install: true
 
 jdk:
-  - oraclejdk7
+  - openjdk7
 
 script:
   - mvn verify -B -e -V

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ checkers.
 | `sonar.buildbreaker.forbiddenConf` | Comma-separated list of `key=value` pairs that should break the build. | | `sonar.gallio.mode=skip` |
 | `sonar.buildbreaker.alternativeServerUrl` | URL to use for web service requests. If unset, uses the `serverUrl` property from `${sonar.working.directory}/report-task.txt`. | | |
 | `sonar.buildbreaker.preview.issuesSeverity` | Fails the build in preview analysis mode if the severity of issues is equal to or more severe than the selection. | `Disabled` | Available selections are (case insensitive): `Disabled`, `INFO`, `MINOR`, `MAJOR`, `CRITICAL`, `BLOCKER` |
-| `sonar.buildbreaker.preview..newIssuesOnly` | Fails the build in preview analysis mode for new issues only | false | |
+| `sonar.buildbreaker.preview.newIssuesOnly` | Fails the build in preview analysis mode for new issues only | true | |
+| `sonar.buildbreaker.preview.silent` | Disable failing the build in preview analysis mode and only log the issues found | false | |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ checkers.
 | `sonar.buildbreaker.forbiddenConf` | Comma-separated list of `key=value` pairs that should break the build. | | `sonar.gallio.mode=skip` |
 | `sonar.buildbreaker.alternativeServerUrl` | URL to use for web service requests. If unset, uses the `serverUrl` property from `${sonar.working.directory}/report-task.txt`. | | |
 | `sonar.buildbreaker.preview.issuesSeverity` | Fails the build in preview analysis mode if the severity of issues is equal to or more severe than the selection. | `Disabled` | Available selections are (case insensitive): `Disabled`, `INFO`, `MINOR`, `MAJOR`, `CRITICAL`, `BLOCKER` |
+| `sonar.buildbreaker.preview..newIssuesOnly` | Fails the build in preview analysis mode for new issues only | false | |
 
 ## Contributing
 

--- a/src/main/java/org/sonar/plugins/buildbreaker/BuildBreakerPlugin.java
+++ b/src/main/java/org/sonar/plugins/buildbreaker/BuildBreakerPlugin.java
@@ -48,6 +48,7 @@ public final class BuildBreakerPlugin extends SonarPlugin {
   static final String ALTERNATIVE_SERVER_URL_KEY = "sonar.buildbreaker.alternativeServerUrl";
 
   static final String ISSUES_SEVERITY_KEY = "sonar.buildbreaker.preview.issuesSeverity";
+  static final String ISSUES_NEWONLY_KEY = "sonar.builderbreaker.preview.newIssuesOnly";
 
   static final String DISABLED = "Disabled";
 
@@ -113,6 +114,13 @@ public final class BuildBreakerPlugin extends SonarPlugin {
                 Severity.CRITICAL,
                 Severity.BLOCKER)
             .defaultValue(DISABLED)
-            .build());
+            .build(),
+        PropertyDefinition.builder(ISSUES_NEWONLY_KEY)
+          .name("Fail New Issues Only (preview analysis)")
+          .description("Fails the build for new issues only")
+          .onQualifiers(Qualifiers.PROJECT)
+          .type(PropertyType.BOOLEAN)
+          .defaultValue("true")
+          .build());
   }
 }

--- a/src/main/java/org/sonar/plugins/buildbreaker/BuildBreakerPlugin.java
+++ b/src/main/java/org/sonar/plugins/buildbreaker/BuildBreakerPlugin.java
@@ -48,7 +48,10 @@ public final class BuildBreakerPlugin extends SonarPlugin {
   static final String ALTERNATIVE_SERVER_URL_KEY = "sonar.buildbreaker.alternativeServerUrl";
 
   static final String ISSUES_SEVERITY_KEY = "sonar.buildbreaker.preview.issuesSeverity";
-  static final String ISSUES_NEWONLY_KEY = "sonar.builderbreaker.preview.newIssuesOnly";
+
+  static final String ISSUES_NEWONLY_KEY = "sonar.buildbreaker.preview.newIssuesOnly";
+
+  static final String ISSUES_SILENT_KEY = "sonar.buildbreaker.preview.silent";
 
   static final String DISABLED = "Disabled";
 
@@ -117,10 +120,17 @@ public final class BuildBreakerPlugin extends SonarPlugin {
             .build(),
         PropertyDefinition.builder(ISSUES_NEWONLY_KEY)
           .name("Fail New Issues Only (preview analysis)")
-          .description("Fails the build for new issues only")
+          .description("Fails the build in preview analysis for new issues only")
           .onQualifiers(Qualifiers.PROJECT)
           .type(PropertyType.BOOLEAN)
           .defaultValue("true")
+          .build(),
+        PropertyDefinition.builder(ISSUES_SILENT_KEY)
+          .name("Issues Silent Mode (preview analysis)")
+          .description("Will not fail the preview analysis build and only log issues that would cause the failure")
+          .onQualifiers(Qualifiers.PROJECT)
+          .type(PropertyType.BOOLEAN)
+          .defaultValue("false")
           .build());
   }
 }

--- a/src/main/java/org/sonar/plugins/buildbreaker/IssuesSeverityBreaker.java
+++ b/src/main/java/org/sonar/plugins/buildbreaker/IssuesSeverityBreaker.java
@@ -51,7 +51,7 @@ public final class IssuesSeverityBreaker implements CheckProject, PostJob, PostJ
   private final int issuesSeveritySettingValue;
 
   private boolean failed = false;
-  private boolean failNewIssuesOnlySetting;
+  private boolean failNewIssuesOnlySetting = true;
 
   /**
    * Constructor used to inject dependencies.
@@ -98,7 +98,7 @@ public final class IssuesSeverityBreaker implements CheckProject, PostJob, PostJ
     for (Issue issue : projectIssues.issues()) {
       if (( issue.isNew() || !failNewIssuesOnlySetting) && Severity.ALL.indexOf(issue.severity()) >= issuesSeveritySettingValue) {
           Integer line = issue.line();
-          LOGGER.info("{}, {}, {} ({})",issue.componentKey(), line == null ? -1 : line.toString(),issue.message(), issue.ruleKey().toString());
+          LOGGER.info("{}, Line {}, {} ({}) , {}",issue.componentKey(), line == null ? -1 : line.toString(),issue.message(), issue.ruleKey().toString(), issue.isNew()? "(New Issue)" : "");
           // only mark failure and fail on PostJobsPhaseHandler.onPostJobsPhase() to ensure other
           // plugins can finish their work, most notably the stash issue reporter plugin
           failed = true;

--- a/src/test/java/org/sonar/plugins/buildbreaker/BuildBreakerPluginTest.java
+++ b/src/test/java/org/sonar/plugins/buildbreaker/BuildBreakerPluginTest.java
@@ -27,6 +27,6 @@ public final class BuildBreakerPluginTest {
 
   @Test
   public void testDeclaredExtensions() {
-    assertEquals(10, new BuildBreakerPlugin().getExtensions().size());
+    assertEquals(11, new BuildBreakerPlugin().getExtensions().size());
   }
 }

--- a/src/test/java/org/sonar/plugins/buildbreaker/BuildBreakerPluginTest.java
+++ b/src/test/java/org/sonar/plugins/buildbreaker/BuildBreakerPluginTest.java
@@ -27,6 +27,6 @@ public final class BuildBreakerPluginTest {
 
   @Test
   public void testDeclaredExtensions() {
-    assertEquals(9, new BuildBreakerPlugin().getExtensions().size());
+    assertEquals(10, new BuildBreakerPlugin().getExtensions().size());
   }
 }

--- a/src/test/java/org/sonar/plugins/buildbreaker/IssuesSeverityBreakerTest.java
+++ b/src/test/java/org/sonar/plugins/buildbreaker/IssuesSeverityBreakerTest.java
@@ -32,6 +32,7 @@ import org.sonar.api.batch.events.PostJobsPhaseHandler.PostJobsPhaseEvent;
 import org.sonar.api.config.Settings;
 import org.sonar.api.issue.Issue;
 import org.sonar.api.issue.ProjectIssues;
+import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rule.Severity;
 
 public final class IssuesSeverityBreakerTest {
@@ -93,8 +94,16 @@ public final class IssuesSeverityBreakerTest {
   public void testSeverityMajorFoundMajor() {
     Issue issue1 = mock(Issue.class);
     when(issue1.severity()).thenReturn(Severity.MINOR);
+    when(issue1.line()).thenReturn(-1);
+    when(issue1.componentKey()).thenReturn("/TestFile.java");
+    when(issue1.message()).thenReturn("A problem occured");
+    when(issue1.ruleKey()).thenReturn(RuleKey.of("Repo", "rule"));
     Issue issue2 = mock(Issue.class);
     when(issue2.severity()).thenReturn(Severity.MAJOR);
+    when(issue2.line()).thenReturn(-1);
+    when(issue2.componentKey()).thenReturn("/TestFile.java");
+    when(issue2.message()).thenReturn("A problem occured");
+    when(issue2.ruleKey()).thenReturn(RuleKey.of("Repo", "rule"));
 
     ProjectIssues projectIssues = mock(ProjectIssues.class);
     when(projectIssues.issues()).thenReturn(Arrays.asList(issue1, issue2));
@@ -118,8 +127,16 @@ public final class IssuesSeverityBreakerTest {
   public void testSeverityMajorFoundCritical() {
     Issue issue1 = mock(Issue.class);
     when(issue1.severity()).thenReturn(Severity.MINOR);
+    when(issue1.line()).thenReturn(-1);
+    when(issue1.componentKey()).thenReturn("/TestFile.java");
+    when(issue1.message()).thenReturn("A problem occured");
+    when(issue1.ruleKey()).thenReturn(RuleKey.of("Repo", "rule"));
     Issue issue2 = mock(Issue.class);
     when(issue2.severity()).thenReturn(Severity.CRITICAL);
+    when(issue2.line()).thenReturn(-1);
+    when(issue2.componentKey()).thenReturn("/TestFile.java");
+    when(issue2.message()).thenReturn("A problem occured");
+    when(issue2.ruleKey()).thenReturn(RuleKey.of("Repo", "rule"));
 
     ProjectIssues projectIssues = mock(ProjectIssues.class);
     when(projectIssues.issues()).thenReturn(Arrays.asList(issue1, issue2));

--- a/src/test/java/org/sonar/plugins/buildbreaker/IssuesSeverityBreakerTest.java
+++ b/src/test/java/org/sonar/plugins/buildbreaker/IssuesSeverityBreakerTest.java
@@ -157,6 +157,39 @@ public final class IssuesSeverityBreakerTest {
   }
 
   @Test
+  public void testIssueSilent() {
+    Issue issue1 = mock(Issue.class);
+    when(issue1.severity()).thenReturn(Severity.MINOR);
+    when(issue1.line()).thenReturn(-1);
+    when(issue1.componentKey()).thenReturn("/TestFile.java");
+    when(issue1.message()).thenReturn("A problem occured");
+    when(issue1.ruleKey()).thenReturn(RuleKey.of("Repo", "rule"));
+    Issue issue2 = mock(Issue.class);
+    when(issue2.severity()).thenReturn(Severity.CRITICAL);
+    when(issue2.line()).thenReturn(-1);
+    when(issue2.componentKey()).thenReturn("/TestFile.java");
+    when(issue2.message()).thenReturn("A problem occured");
+    when(issue2.ruleKey()).thenReturn(RuleKey.of("Repo", "rule"));
+
+    ProjectIssues projectIssues = mock(ProjectIssues.class);
+    when(projectIssues.issues()).thenReturn(Arrays.asList(issue1, issue2));
+
+    Settings settings = new Settings();
+    settings.setProperty(BuildBreakerPlugin.ISSUES_SEVERITY_KEY, Severity.MAJOR);
+    settings.setProperty(BuildBreakerPlugin.ISSUES_SILENT_KEY, true);
+
+    IssuesSeverityBreaker breaker = new IssuesSeverityBreaker(null, projectIssues, settings);
+    breaker.executeOn(null, null);
+
+    PostJobsPhaseEvent postJobsPhaseEvent = mock(PostJobsPhaseEvent.class);
+    when(postJobsPhaseEvent.isEnd()).thenReturn(true);
+
+  // No exception as swallowed and logged
+
+    breaker.onPostJobsPhase(postJobsPhaseEvent);
+  }
+
+  @Test
   public void testSeverityMajorFoundNone() {
     Issue issue1 = mock(Issue.class);
     when(issue1.severity()).thenReturn(Severity.INFO);


### PR DESCRIPTION
This pull request adds a few additional options to the Issues Severity Analysis:

- newIssuesOnly: When enabled only new issues will fail the build. We have a legacy of debt so only want newly introduced issues to be flagged for fixing. 
- silentMode: The build is not broken but all the issues are still logged. This allows people to test out the plugin without enabling. 
- All issues logged: When the build is broken the users can easily find out what the issues are without having to use another tool/plugin to find out the issues. 
