### PR TITLE
Use sonar.scanner.metadataFilePath if set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 install: true
 
 jdk:
-  - oraclejdk7
+  - oraclejdk9
 
 script:
   - mvn verify -B -e -V

--- a/pom.xml
+++ b/pom.xml
@@ -77,18 +77,16 @@
             <version>${sonar.version}</version>
         </dependency>
         <!-- unit tests -->
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>1.6.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.6.4</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito2</artifactId>
+			<version>2.0.0-RC.4</version>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<version>2.0.0-RC.4</version>
+		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
 		<dependency>
 		    <groupId>com.google.guava</groupId>
@@ -127,7 +125,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.5.201505241946</version>
+                <version>0.7.8</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,157 +1,168 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonarsource.parent</groupId>
-    <artifactId>parent</artifactId>
-    <version>26</version>
-  </parent>
+    <parent>
+        <groupId>org.sonarsource.parent</groupId>
+        <artifactId>parent</artifactId>
+        <version>26</version>
+    </parent>
 
-  <groupId>org.sonarqubecommunity.buildbreaker</groupId>
-  <artifactId>sonar-build-breaker-plugin</artifactId>
-  <version>2.3-SNAPSHOT</version>
-  <packaging>sonar-plugin</packaging>
+    <groupId>org.sonarqubecommunity.buildbreaker</groupId>
+    <artifactId>sonar-build-breaker-plugin</artifactId>
+    <version>2.3-SNAPSHOT</version>
+    <packaging>sonar-plugin</packaging>
 
-  <name>SonarQube Build Breaker Plugin</name>
-  <description>Break the analyzer if the project does not pass its Quality Gate</description>
-  <url>https://github.com/SonarQubeCommunity/sonar-build-breaker</url>
-  <inceptionYear>2009</inceptionYear>
-
-  <organization>
-    <name>Matthew DeTullio and contributors</name>
-    <url>mailto:sonarqube@googlegroups.com</url>
-  </organization>
-
-  <developers>
-    <developer>
-      <id>mjdetullio</id>
-      <name>Matthew DeTullio</name>
-    </developer>
-  </developers>
-
-  <licenses>
-    <license>
-      <name>GNU LGPL 3</name>
-      <url>http://www.gnu.org/licenses/lgpl.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <scm>
-    <connection>scm:git:git@github.com:SonarQubeCommunity/sonar-build-breaker.git</connection>
-    <developerConnection>scm:git:git@github.com:SonarQubeCommunity/sonar-build-breaker.git</developerConnection>
+    <name>SonarQube Build Breaker Plugin</name>
+    <description>Break the analyzer if the project does not pass its Quality Gate</description>
     <url>https://github.com/SonarQubeCommunity/sonar-build-breaker</url>
-    <tag>HEAD</tag>
-  </scm>
+    <inceptionYear>2009</inceptionYear>
 
-  <issueManagement>
-    <system>GitHub</system>
-    <url>https://github.com/SonarQubeCommunity/sonar-build-breaker/issues</url>
-  </issueManagement>
+    <organization>
+        <name>Matthew DeTullio and contributors</name>
+        <url>mailto:sonarqube@googlegroups.com</url>
+    </organization>
 
-  <ciManagement>
-    <system>Travis</system>
-    <url>https://travis-ci.org/SonarQubeCommunity/sonar-build-breaker</url>
-  </ciManagement>
+    <developers>
+        <developer>
+            <id>mjdetullio</id>
+            <name>Matthew DeTullio</name>
+        </developer>
+    </developers>
 
-  <properties>
-    <license.owner>${project.organization.name}</license.owner>
-    <license.mailto>${project.organization.url}</license.mailto>
-    <sonar.version>5.3</sonar.version>
-    <sonar.pluginName>Build Breaker</sonar.pluginName>
-    <sonar.pluginClass>org.sonar.plugins.buildbreaker.BuildBreakerPlugin</sonar.pluginClass>
-    <!-- Last JDK 1.7 compatible packaging plugin version -->
-    <version.sonar-packaging.plugin>1.16</version.sonar-packaging.plugin>
-  </properties>
+    <licenses>
+        <license>
+            <name>GNU LGPL 3</name>
+            <url>http://www.gnu.org/licenses/lgpl.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-plugin-api</artifactId>
-      <version>${sonar.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
-      <artifactId>sonar-ws</artifactId>
-      <version>${sonar.version}</version>
-    </dependency>
-    <!-- unit tests -->
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.4</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.4</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4.1</version>
-        <executions>
-          <execution>
-            <id>enforce-java</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireJavaVersion>
-                  <!-- PowerMock doesn't like these versions http://stackoverflow.com/a/25428318 -->
-                  <version>[1.7.0,1.7.0-65),[1.7.0-75,)</version>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.5.201505241946</version>
-        <executions>
-          <execution>
-            <id>default-prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>default-report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <tagNameFormat>@{project.version}</tagNameFormat>
-          <autoVersionSubmodules>true</autoVersionSubmodules>
-          <useReleaseProfile>false</useReleaseProfile>
-          <localCheckout>true</localCheckout>
-          <pushChanges>false</pushChanges>
-          <mavenExecutorId>forked-path</mavenExecutorId>
-          <preparationGoals>clean install</preparationGoals>
-          <goals>clean install</goals>
-          <!--
-          Allows to activate release profile during release.
-          We don't use releaseProfiles parameter, because it affects only release:perform goal
-          -->
-          <arguments>-Prelease</arguments>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    <scm>
+        <connection>scm:git:git@github.com:SonarQubeCommunity/sonar-build-breaker.git</connection>
+        <developerConnection>scm:git:git@github.com:SonarQubeCommunity/sonar-build-breaker.git</developerConnection>
+        <url>https://github.com/SonarQubeCommunity/sonar-build-breaker</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/SonarQubeCommunity/sonar-build-breaker/issues</url>
+    </issueManagement>
+
+    <ciManagement>
+        <system>Travis</system>
+        <url>https://travis-ci.org/SonarQubeCommunity/sonar-build-breaker</url>
+    </ciManagement>
+
+    <properties>
+        <license.owner>${project.organization.name}</license.owner>
+        <license.mailto>${project.organization.url}</license.mailto>
+        <sonar.version>7.9</sonar.version>
+        <sonar.pluginName>Build Breaker</sonar.pluginName>
+        <sonar.pluginClass>org.sonar.plugins.buildbreaker.BuildBreakerPlugin</sonar.pluginClass>
+        <version.sonar-packaging.plugin>1.17</version.sonar-packaging.plugin>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.sonarsource.sonarqube</groupId>
+            <artifactId>sonar-plugin-api</artifactId>
+            <version>${sonar.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.sonarsource.sonarqube</groupId>
+            <artifactId>sonar-ws</artifactId>
+            <version>${sonar.version}</version>
+        </dependency>
+        <!-- unit tests -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>1.6.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>1.6.4</version>
+            <scope>test</scope>
+        </dependency>
+		<!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
+		<dependency>
+		    <groupId>com.google.guava</groupId>
+		    <artifactId>guava</artifactId>
+		    <version>28.0-jre</version>
+		</dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.16</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-java</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <!-- PowerMock doesn't like these versions http://stackoverflow.com/a/25428318 -->
+                                    <version>[1.7.0,1.7.0-65),[1.7.0-75,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.5.201505241946</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <tagNameFormat>@{project.version}</tagNameFormat>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <localCheckout>true</localCheckout>
+                    <pushChanges>false</pushChanges>
+                    <mavenExecutorId>forked-path</mavenExecutorId>
+                    <preparationGoals>clean install</preparationGoals>
+                    <goals>clean install</goals>
+                    <!--
+                    Allows to activate release profile during release.
+                    We don't use releaseProfiles parameter, because it affects only release:perform goal
+                    -->
+                    <arguments>-Prelease</arguments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/org/sonar/plugins/buildbreaker/ForbiddenConfigurationBreaker.java
+++ b/src/main/java/org/sonar/plugins/buildbreaker/ForbiddenConfigurationBreaker.java
@@ -20,20 +20,20 @@
 package org.sonar.plugins.buildbreaker;
 
 import com.google.common.base.Splitter;
-import java.util.List;
-import org.sonar.api.batch.CheckProject;
-import org.sonar.api.batch.PostJob;
-import org.sonar.api.batch.SensorContext;
+import org.sonar.api.batch.postjob.PostJob;
+import org.sonar.api.batch.postjob.PostJobContext;
+import org.sonar.api.batch.postjob.PostJobDescriptor;
 import org.sonar.api.config.Settings;
-import org.sonar.api.resources.Project;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
+
+import java.util.List;
 
 /**
  * Checks the analysis parameters for forbidden configurations. Breaks the build if at least one of
  * the comma-separated key=value configurations was found.
  */
-public final class ForbiddenConfigurationBreaker implements CheckProject, PostJob {
+public final class ForbiddenConfigurationBreaker implements PostJob {
 
   private static final Logger LOGGER = Loggers.get(ForbiddenConfigurationBreaker.class);
 
@@ -48,25 +48,31 @@ public final class ForbiddenConfigurationBreaker implements CheckProject, PostJo
     this.settings = settings;
   }
 
-  @Override
-  public boolean shouldExecuteOnProject(Project project) {
+  public boolean shouldExecuteOnProject() {
     return settings.hasKey(BuildBreakerPlugin.FORBIDDEN_CONF_KEY);
   }
 
   @Override
-  public void executeOn(Project project, SensorContext context) {
-    String[] pairs = settings.getStringArray(BuildBreakerPlugin.FORBIDDEN_CONF_KEY);
-    for (String pair : pairs) {
-      List<String> split = Splitter.on('=').limit(2).splitToList(pair);
-      if (split.isEmpty()) {
-        continue;
-      }
-      String key = split.get(0);
-      String value = split.size() > 1 ? split.get(1) : "";
-      if (value.equals(settings.getString(key))) {
-        LOGGER.error("{} Forbidden configuration: {}", BuildBreakerPlugin.LOG_STAMP, pair);
-        throw new IllegalStateException(
-            "A forbidden configuration has been found on the project: " + pair);
+  public void describe(PostJobDescriptor descriptor) {
+    descriptor.name("Forbidden Configuration Breaker");
+  }
+
+  @Override
+  public void execute(PostJobContext context) {
+    if (shouldExecuteOnProject()) {
+      String[] pairs = settings.getStringArray(BuildBreakerPlugin.FORBIDDEN_CONF_KEY);
+      for (String pair : pairs) {
+        List<String> split = Splitter.on('=').limit(2).splitToList(pair);
+        if (split.isEmpty()) {
+          continue;
+        }
+        String key = split.get(0);
+        String value = split.size() > 1 ? split.get(1) : "";
+        if (value.equals(settings.getString(key))) {
+          LOGGER.error("{} Forbidden configuration: {}", BuildBreakerPlugin.LOG_STAMP, pair);
+          throw new IllegalStateException(
+              "A forbidden configuration has been found on the project: " + pair);
+        }
       }
     }
   }

--- a/src/main/java/org/sonar/plugins/buildbreaker/IssuesSeverityBreaker.java
+++ b/src/main/java/org/sonar/plugins/buildbreaker/IssuesSeverityBreaker.java
@@ -20,62 +20,37 @@
 package org.sonar.plugins.buildbreaker;
 
 import com.google.common.base.Strings;
-import java.util.Locale;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.batch.AnalysisMode;
-import org.sonar.api.batch.CheckProject;
-import org.sonar.api.batch.PostJob;
-import org.sonar.api.batch.SensorContext;
-import org.sonar.api.batch.events.PostJobsPhaseHandler;
+import org.sonar.api.batch.postjob.PostJob;
+import org.sonar.api.batch.postjob.PostJobContext;
+import org.sonar.api.batch.postjob.PostJobDescriptor;
 import org.sonar.api.config.Settings;
 import org.sonar.api.issue.Issue;
-import org.sonar.api.issue.ProjectIssues;
-import org.sonar.api.resources.Project;
+import org.sonar.api.batch.postjob.issue.PostJobIssue;
+import org.sonar.api.batch.AnalysisMode;
 import org.sonar.api.rule.Severity;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
+
+import java.util.Locale;
 
 /**
  * Checks the project's issues for the configured severity level or higher. Breaks the build if any
  * issues at those severities are found.
  */
-public final class IssuesSeverityBreaker implements CheckProject, PostJob, PostJobsPhaseHandler {
+public final class IssuesSeverityBreaker implements PostJob{
   private static final String CLASSNAME = IssuesSeverityBreaker.class.getSimpleName();
 
   private static final Logger LOGGER = Loggers.get(ForbiddenConfigurationBreaker.class);
 
-  private final AnalysisMode analysisMode;
-  private final ProjectIssues projectIssues;
-  private final String issuesSeveritySetting;
-  private final int issuesSeveritySettingValue;
-
   private boolean failed = false;
 
-  /**
-   * Constructor used to inject dependencies.
-   *
-   * @param analysisMode the analysis mode
-   * @param projectIssues the project's issues
-   * @param settings the project settings
-   */
-  public IssuesSeverityBreaker(
-      AnalysisMode analysisMode, ProjectIssues projectIssues, Settings settings) {
-    this.analysisMode = analysisMode;
-    this.projectIssues = projectIssues;
-    issuesSeveritySetting =
-        Strings.nullToEmpty(settings.getString(BuildBreakerPlugin.ISSUES_SEVERITY_KEY))
-            .toUpperCase(Locale.US);
-    issuesSeveritySettingValue = Severity.ALL.indexOf(issuesSeveritySetting);
-  }
-
-  @Override
-  public boolean shouldExecuteOnProject(Project project) {
+  public boolean shouldExecuteOnProject(AnalysisMode analysisMode, String issuesSeveritySetting, int issuesSeveritySettingValue) {
     if (analysisMode.isPublish()) {
       LOGGER.debug(
-          "{} is disabled ({} == {})",
-          CLASSNAME,
-          CoreProperties.ANALYSIS_MODE,
-          CoreProperties.ANALYSIS_MODE_PUBLISH);
+          "{} is disabled",
+          CLASSNAME);
       return false;
     }
     if (issuesSeveritySettingValue < 0) {
@@ -90,24 +65,29 @@ public final class IssuesSeverityBreaker implements CheckProject, PostJob, PostJ
   }
 
   @Override
-  public void executeOn(Project project, SensorContext context) {
-    for (Issue issue : projectIssues.issues()) {
-      if (Severity.ALL.indexOf(issue.severity()) >= issuesSeveritySettingValue) {
-        // only mark failure and fail on PostJobsPhaseHandler.onPostJobsPhase() to ensure other
-        // plugins can finish their work, most notably the stash issue reporter plugin
-        failed = true;
-        return;
-      }
-    }
+  public void describe(PostJobDescriptor descriptor) {
+    descriptor.name("Issues Severity Breaker");
   }
 
   @Override
-  public void onPostJobsPhase(PostJobsPhaseEvent event) {
-    if (event.isEnd() && failed) {
-      String failureMessage =
-          "Project contains issues with severity equal to or higher than " + issuesSeveritySetting;
-      LOGGER.error("{} {}", BuildBreakerPlugin.LOG_STAMP, failureMessage);
-      throw new IllegalStateException(failureMessage);
+  public void execute(PostJobContext postJobContext) {
+	final AnalysisMode analysisMode = postJobContext.analysisMode();
+	final String issuesSeveritySetting =
+            Strings.nullToEmpty(postJobContext.settings().getString(BuildBreakerPlugin.ISSUES_SEVERITY_KEY))
+                .toUpperCase(Locale.US);
+    int issuesSeveritySettingValue = Severity.ALL.indexOf(issuesSeveritySetting);
+	  
+    if (shouldExecuteOnProject(analysisMode, issuesSeveritySetting, issuesSeveritySettingValue)){    	
+      for (PostJobIssue issue : postJobContext.issues()) {
+        if (issue.severity().ordinal() >= issuesSeveritySettingValue) {
+          // only mark failure and fail on PostJobsPhaseHandler.onPostJobsPhase() to ensure other
+          // plugins can finish their work, most notably the stash issue reporter plugin
+          String failureMessage =
+                  "Project contains issues with severity equal to or higher than " + issuesSeveritySetting;
+          LOGGER.error("{} {}", BuildBreakerPlugin.LOG_STAMP, failureMessage);
+          throw new IllegalStateException(failureMessage);
+        }
+      }
     }
   }
 }

--- a/src/main/java/org/sonar/plugins/buildbreaker/QualityGateBreaker.java
+++ b/src/main/java/org/sonar/plugins/buildbreaker/QualityGateBreaker.java
@@ -19,48 +19,43 @@
  */
 package org.sonar.plugins.buildbreaker;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Files;
+import org.sonar.api.CoreProperties;
+import org.sonar.api.batch.AnalysisMode;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.postjob.PostJob;
+import org.sonar.api.batch.postjob.PostJobContext;
+import org.sonar.api.batch.postjob.PostJobDescriptor;
+import org.sonar.api.config.Settings;
+import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.Metric;
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+import org.sonarqube.ws.Ce.TaskStatus;
+import org.sonarqube.ws.Ce.TaskResponse;
+import org.sonarqube.ws.MediaTypes;
+import org.sonarqube.ws.Qualitygates.ProjectStatusResponse;
+import org.sonarqube.ws.Qualitygates.ProjectStatusResponse.Comparator;
+import org.sonarqube.ws.Qualitygates.ProjectStatusResponse.Condition;
+import org.sonarqube.ws.Qualitygates.ProjectStatusResponse.ProjectStatus;
+import org.sonarqube.ws.Qualitygates.ProjectStatusResponse.Status;
+import org.sonarqube.ws.client.*;
+import org.sonarqube.ws.client.qualitygates.ProjectStatusRequest;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Properties;
-import org.sonar.api.CoreProperties;
-import org.sonar.api.batch.AnalysisMode;
-import org.sonar.api.batch.CheckProject;
-import org.sonar.api.batch.PostJob;
-import org.sonar.api.batch.SensorContext;
-import org.sonar.api.batch.fs.FileSystem;
-import org.sonar.api.config.Settings;
-import org.sonar.api.measures.CoreMetrics;
-import org.sonar.api.measures.Metric;
-import org.sonar.api.resources.Project;
-import org.sonar.api.utils.log.Logger;
-import org.sonar.api.utils.log.Loggers;
-import org.sonarqube.ws.MediaTypes;
-import org.sonarqube.ws.WsCe.TaskResponse;
-import org.sonarqube.ws.WsCe.TaskStatus;
-import org.sonarqube.ws.WsQualityGates.ProjectStatusWsResponse;
-import org.sonarqube.ws.WsQualityGates.ProjectStatusWsResponse.Comparator;
-import org.sonarqube.ws.WsQualityGates.ProjectStatusWsResponse.Condition;
-import org.sonarqube.ws.WsQualityGates.ProjectStatusWsResponse.ProjectStatus;
-import org.sonarqube.ws.WsQualityGates.ProjectStatusWsResponse.Status;
-import org.sonarqube.ws.client.GetRequest;
-import org.sonarqube.ws.client.HttpConnector;
-import org.sonarqube.ws.client.HttpWsClient;
-import org.sonarqube.ws.client.WsClient;
-import org.sonarqube.ws.client.WsRequest;
-import org.sonarqube.ws.client.WsResponse;
-import org.sonarqube.ws.client.qualitygate.ProjectStatusWsRequest;
 
 /**
  * Retrieves the ID of the server-side Compute Engine task, waits for task completion, then checks
  * the project's quality gate. Breaks the build if the quality gate has failed.
  */
-public final class QualityGateBreaker implements CheckProject, PostJob {
+public final class QualityGateBreaker implements PostJob {
   private static final String CLASSNAME = QualityGateBreaker.class.getSimpleName();
   private static final Logger LOGGER = Loggers.get(QualityGateBreaker.class);
 
@@ -81,14 +76,62 @@ public final class QualityGateBreaker implements CheckProject, PostJob {
     this.settings = settings;
   }
 
-  @Override
-  public boolean shouldExecuteOnProject(Project project) {
+  @VisibleForTesting
+  static int logConditions(List<Condition> conditionsList) {
+    int errors = 0;
+
+    for (Condition condition : conditionsList) {
+      if (Status.WARN.equals(condition.getStatus())) {
+        LOGGER.warn(
+            "{}: {} {} {}",
+            getMetricName(condition.getMetricKey()),
+            condition.getActualValue(),
+            getComparatorSymbol(condition.getComparator()),
+            condition.getWarningThreshold());
+      } else if (Status.ERROR.equals(condition.getStatus())) {
+        errors++;
+        LOGGER.error(
+            "{}: {} {} {}",
+            getMetricName(condition.getMetricKey()),
+            condition.getActualValue(),
+            getComparatorSymbol(condition.getComparator()),
+            condition.getErrorThreshold());
+      }
+    }
+
+    return errors;
+  }
+
+  private static String getMetricName(String metricKey) {
+    try {
+      Metric metric = CoreMetrics.getMetric(metricKey);
+      return metric.getName();
+    } catch (NoSuchElementException e) {
+      LOGGER.trace("Using key as name for custom metric '{}' due to '{}'", metricKey, e);
+    }
+    return metricKey;
+  }
+
+  private static String getComparatorSymbol(Comparator comparator) {
+    switch (comparator) {
+      case GT:
+        return ">";
+      case LT:
+        return "<";
+      case EQ:
+        return "=";
+      case NE:
+        return "!=";
+      default:
+        return comparator.toString();
+    }
+  }
+
+  public boolean shouldExecuteOnProject() {
     if (!analysisMode.isPublish()) {
       LOGGER.debug(
-          "{} is disabled ({} != {})",
-          CLASSNAME,
-          CoreProperties.ANALYSIS_MODE,
-          CoreProperties.ANALYSIS_MODE_PUBLISH);
+          "{} is disabled",
+          CLASSNAME);
       return false;
     }
     if (settings.getBoolean(BuildBreakerPlugin.SKIP_KEY)) {
@@ -96,25 +139,6 @@ public final class QualityGateBreaker implements CheckProject, PostJob {
       return false;
     }
     return true;
-  }
-
-  @Override
-  public void executeOn(Project project, SensorContext context) {
-    Properties reportTaskProps = loadReportTaskProps();
-
-    HttpConnector httpConnector =
-        new HttpConnector.Builder()
-            .url(getServerUrl(reportTaskProps))
-            .credentials(
-                settings.getString(CoreProperties.LOGIN),
-                settings.getString(CoreProperties.PASSWORD))
-            .build();
-
-    WsClient wsClient = new HttpWsClient(httpConnector);
-
-    String analysisId = getAnalysisId(wsClient, reportTaskProps.getProperty("ceTaskId"));
-
-    checkQualityGate(wsClient, analysisId);
   }
 
   private String getServerUrl(Properties reportTaskProps) {
@@ -192,10 +216,8 @@ public final class QualityGateBreaker implements CheckProject, PostJob {
   @VisibleForTesting
   void checkQualityGate(WsClient wsClient, String analysisId) {
     LOGGER.debug("Requesting quality gate status for analysisId {}", analysisId);
-    ProjectStatusWsResponse projectStatusResponse =
-        wsClient
-            .qualityGates()
-            .projectStatus(new ProjectStatusWsRequest().setAnalysisId(analysisId));
+    ProjectStatusResponse projectStatusResponse =
+        wsClient.qualitygates().projectStatus(new ProjectStatusRequest().setAnalysisId(analysisId));
 
     ProjectStatus projectStatus = projectStatusResponse.getProjectStatus();
 
@@ -213,54 +235,29 @@ public final class QualityGateBreaker implements CheckProject, PostJob {
     }
   }
 
-  @VisibleForTesting
-  static int logConditions(List<Condition> conditionsList) {
-    int errors = 0;
-
-    for (Condition condition : conditionsList) {
-      if (Status.WARN.equals(condition.getStatus())) {
-        LOGGER.warn(
-            "{}: {} {} {}",
-            getMetricName(condition.getMetricKey()),
-            condition.getActualValue(),
-            getComparatorSymbol(condition.getComparator()),
-            condition.getWarningThreshold());
-      } else if (Status.ERROR.equals(condition.getStatus())) {
-        errors++;
-        LOGGER.error(
-            "{}: {} {} {}",
-            getMetricName(condition.getMetricKey()),
-            condition.getActualValue(),
-            getComparatorSymbol(condition.getComparator()),
-            condition.getErrorThreshold());
-      }
-    }
-
-    return errors;
+  @Override
+  public void describe(PostJobDescriptor descriptor) {
+    descriptor.name("Quality Gate Breaker");
   }
 
-  private static String getMetricName(String metricKey) {
-    try {
-      Metric metric = CoreMetrics.getMetric(metricKey);
-      return metric.getName();
-    } catch (NoSuchElementException e) {
-      LOGGER.trace("Using key as name for custom metric '{}' due to '{}'", metricKey, e);
-    }
-    return metricKey;
-  }
+  @Override
+  public void execute(PostJobContext postJobContext) {
+    if (shouldExecuteOnProject()) {
+      Properties reportTaskProps = loadReportTaskProps();
 
-  private static String getComparatorSymbol(Comparator comparator) {
-    switch (comparator) {
-      case GT:
-        return ">";
-      case LT:
-        return "<";
-      case EQ:
-        return "=";
-      case NE:
-        return "!=";
-      default:
-        return comparator.toString();
+      HttpConnector httpConnector =
+          HttpConnector.newBuilder()
+              .url(getServerUrl(reportTaskProps))
+              .credentials(
+                  settings.getString(CoreProperties.LOGIN),
+                  settings.getString(CoreProperties.PASSWORD))
+              .build();
+
+      WsClient wsClient = WsClientFactories.getDefault().newClient(httpConnector);
+
+      String analysisId = getAnalysisId(wsClient, reportTaskProps.getProperty("ceTaskId"));
+
+      checkQualityGate(wsClient, analysisId);
     }
   }
 }

--- a/src/main/java/org/sonar/plugins/buildbreaker/QualityGateBreaker.java
+++ b/src/main/java/org/sonar/plugins/buildbreaker/QualityGateBreaker.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.plugins.buildbreaker;
 
-import com.google.common.base.Strings;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.io.Files;
 import org.sonar.api.CoreProperties;
 import org.sonar.api.batch.AnalysisMode;
@@ -33,8 +33,8 @@ import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.Metric;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
-import org.sonarqube.ws.Ce.TaskStatus;
 import org.sonarqube.ws.Ce.TaskResponse;
+import org.sonarqube.ws.Ce.TaskStatus;
 import org.sonarqube.ws.MediaTypes;
 import org.sonarqube.ws.Qualitygates.ProjectStatusResponse;
 import org.sonarqube.ws.Qualitygates.ProjectStatusResponse.Comparator;
@@ -58,6 +58,7 @@ import java.util.Properties;
 public class QualityGateBreaker implements PostJob {
   private static final String CLASSNAME = QualityGateBreaker.class.getSimpleName();
   private static final Logger LOGGER = Loggers.get(QualityGateBreaker.class);
+  static final String SONAR_PROPERTY_METADATA_FILE_PATH = "sonar.scanner.metadataFilePath";
 
   private final AnalysisMode analysisMode;
   private final FileSystem fileSystem;
@@ -155,7 +156,7 @@ public class QualityGateBreaker implements PostJob {
   }
 
   private Properties loadReportTaskProps() {
-    File reportTaskFile = new File(fileSystem.workDir(), "report-task.txt");
+    File reportTaskFile = getReportTaskFilePath();
 
     Properties reportTaskProps = new Properties();
 
@@ -166,6 +167,16 @@ public class QualityGateBreaker implements PostJob {
     }
 
     return reportTaskProps;
+  }
+
+  private File getReportTaskFilePath() {
+    if (settings.getProperties().containsKey(SONAR_PROPERTY_METADATA_FILE_PATH)) {
+      String path = settings.getProperties().get(SONAR_PROPERTY_METADATA_FILE_PATH);
+
+      return fileSystem.resolvePath(path);
+    }
+
+    return new File(fileSystem.workDir(), "report-task.txt");
   }
 
   @VisibleForTesting

--- a/src/main/java/org/sonar/plugins/buildbreaker/QualityGateBreaker.java
+++ b/src/main/java/org/sonar/plugins/buildbreaker/QualityGateBreaker.java
@@ -55,7 +55,7 @@ import java.util.Properties;
  * Retrieves the ID of the server-side Compute Engine task, waits for task completion, then checks
  * the project's quality gate. Breaks the build if the quality gate has failed.
  */
-public final class QualityGateBreaker implements PostJob {
+public class QualityGateBreaker implements PostJob {
   private static final String CLASSNAME = QualityGateBreaker.class.getSimpleName();
   private static final Logger LOGGER = Loggers.get(QualityGateBreaker.class);
 
@@ -169,6 +169,11 @@ public final class QualityGateBreaker implements PostJob {
   }
 
   @VisibleForTesting
+  TaskResponse getTask(WsResponse wsResponse) throws IOException {
+	  return TaskResponse.parseFrom(wsResponse.contentStream());
+  }
+  
+  @VisibleForTesting
   String getAnalysisId(WsClient wsClient, String ceTaskId) {
     WsRequest ceTaskRequest =
         new GetRequest("api/ce/task").setParam("id", ceTaskId).setMediaType(MediaTypes.PROTOBUF);
@@ -180,7 +185,7 @@ public final class QualityGateBreaker implements PostJob {
       WsResponse wsResponse = wsClient.wsConnector().call(ceTaskRequest);
 
       try {
-        TaskResponse taskResponse = TaskResponse.parseFrom(wsResponse.contentStream());
+        TaskResponse taskResponse = getTask(wsResponse);
         TaskStatus taskStatus = taskResponse.getTask().getStatus();
 
         switch (taskStatus) {

--- a/src/test/java/org/sonar/plugins/buildbreaker/ForbiddenConfigurationBreakerTest.java
+++ b/src/test/java/org/sonar/plugins/buildbreaker/ForbiddenConfigurationBreakerTest.java
@@ -25,6 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.sonar.api.config.Settings;
+import org.sonar.api.config.internal.MapSettings;
 
 public final class ForbiddenConfigurationBreakerTest {
 
@@ -32,22 +33,22 @@ public final class ForbiddenConfigurationBreakerTest {
 
   @Test
   public void testShouldExecuteSuccess() {
-    Settings settings = new Settings();
+    Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.FORBIDDEN_CONF_KEY, "foo=bar,hello=world");
 
-    assertEquals(true, new ForbiddenConfigurationBreaker(settings).shouldExecuteOnProject(null));
+    assertEquals(true, new ForbiddenConfigurationBreaker(settings).shouldExecuteOnProject());
   }
 
   @Test
   public void testShouldExecuteFailure() {
-    Settings settings = new Settings();
+    Settings settings = new MapSettings();
 
-    assertEquals(false, new ForbiddenConfigurationBreaker(settings).shouldExecuteOnProject(null));
+    assertEquals(false, new ForbiddenConfigurationBreaker(settings).shouldExecuteOnProject());
   }
 
   @Test
   public void shouldNotFailWithoutAnyForbiddenConfSet() {
-    new ForbiddenConfigurationBreaker(new Settings()).executeOn(null, null);
+    new ForbiddenConfigurationBreaker(new MapSettings()).shouldExecuteOnProject();
     // no exception expected
   }
 
@@ -56,20 +57,20 @@ public final class ForbiddenConfigurationBreakerTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("A forbidden configuration has been found on the project: foo=bar");
 
-    Settings settings = new Settings();
+    Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.FORBIDDEN_CONF_KEY, "foo=bar,hello=world");
     settings.setProperty("foo", "bar");
 
-    new ForbiddenConfigurationBreaker(settings).executeOn(null, null);
+    new ForbiddenConfigurationBreaker(settings).execute(null);
   }
 
   @Test
   public void shouldNotFailIfForbiddenPropertyValueIsDifferent() {
-    Settings settings = new Settings();
+    Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.FORBIDDEN_CONF_KEY, "foo=bar,hello=world");
     settings.setProperty("foo", "other_value");
 
-    new ForbiddenConfigurationBreaker(settings).executeOn(null, null);
+    new ForbiddenConfigurationBreaker(settings).execute(null);
     // no exception expected
   }
 
@@ -78,10 +79,10 @@ public final class ForbiddenConfigurationBreakerTest {
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("A forbidden configuration has been found on the project: foo=true");
 
-    Settings settings = new Settings();
+    Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.FORBIDDEN_CONF_KEY, "foo=true");
     settings.setProperty("foo", true);
 
-    new ForbiddenConfigurationBreaker(settings).executeOn(null, null);
+    new ForbiddenConfigurationBreaker(settings).execute(null);
   }
 }

--- a/src/test/java/org/sonar/plugins/buildbreaker/QualityGateBreakerTest.java
+++ b/src/test/java/org/sonar/plugins/buildbreaker/QualityGateBreakerTest.java
@@ -24,6 +24,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -156,20 +158,21 @@ public final class QualityGateBreakerTest {
     WsClient wsClient = mock(WsClient.class);
     WsConnector wsConnector = mock(WsConnector.class);
     WsResponse wsResponse = mock(WsResponse.class);
-    // yuck
-    PowerMockito.mockStatic(TaskResponse.class);
+
     TaskResponse taskResponse = mock(TaskResponse.class);
     Task task = Task.newBuilder().setStatus(TaskStatus.IN_PROGRESS).build();
 
     when(wsClient.wsConnector()).thenReturn(wsConnector);
     when(wsConnector.call(any(WsRequest.class))).thenReturn(wsResponse);
-    when(TaskResponse.parseFrom(any(InputStream.class))).thenReturn(taskResponse);
     when(taskResponse.getTask()).thenReturn(task);
 
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Report processing is taking longer than the configured wait limit.");
 
-    new QualityGateBreaker(null, fileSystem, settings).getAnalysisId(wsClient, TEST_TASK_ID);
+    QualityGateBreaker qualityGateBreaker = Mockito.spy(new QualityGateBreaker(null, fileSystem, settings));
+    Mockito.doReturn(taskResponse).when(qualityGateBreaker).getTask(wsResponse);
+    
+	qualityGateBreaker.getAnalysisId(wsClient, TEST_TASK_ID);
   }
 
   @Test
@@ -182,20 +185,21 @@ public final class QualityGateBreakerTest {
     WsClient wsClient = mock(WsClient.class);
     WsConnector wsConnector = mock(WsConnector.class);
     WsResponse wsResponse = mock(WsResponse.class);
-    // yuck
-    PowerMockito.mockStatic(TaskResponse.class);
+
     TaskResponse taskResponse = mock(TaskResponse.class);
     Task task = Task.newBuilder().setStatus(TaskStatus.PENDING).build();
 
     when(wsClient.wsConnector()).thenReturn(wsConnector);
     when(wsConnector.call(any(WsRequest.class))).thenReturn(wsResponse);
-    when(TaskResponse.parseFrom(any(InputStream.class))).thenReturn(taskResponse);
     when(taskResponse.getTask()).thenReturn(task);
 
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Report processing is taking longer than the configured wait limit.");
 
-    new QualityGateBreaker(null, fileSystem, settings).getAnalysisId(wsClient, TEST_TASK_ID);
+    QualityGateBreaker qualityGateBreaker = Mockito.spy(new QualityGateBreaker(null, fileSystem, settings));
+    Mockito.doReturn(taskResponse).when(qualityGateBreaker).getTask(wsResponse);
+    
+	qualityGateBreaker.getAnalysisId(wsClient, TEST_TASK_ID);
   }
 
   @Test
@@ -208,20 +212,21 @@ public final class QualityGateBreakerTest {
     WsClient wsClient = mock(WsClient.class);
     WsConnector wsConnector = mock(WsConnector.class);
     WsResponse wsResponse = mock(WsResponse.class);
-    // yuck
-    PowerMockito.mockStatic(TaskResponse.class);
+
     TaskResponse taskResponse = mock(TaskResponse.class);
     Task task = Task.newBuilder().setStatus(TaskStatus.FAILED).build();
 
     when(wsClient.wsConnector()).thenReturn(wsConnector);
     when(wsConnector.call(any(WsRequest.class))).thenReturn(wsResponse);
-    when(TaskResponse.parseFrom(any(InputStream.class))).thenReturn(taskResponse);
     when(taskResponse.getTask()).thenReturn(task);
 
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Report processing did not complete successfully: FAILED");
 
-    new QualityGateBreaker(null, fileSystem, settings).getAnalysisId(wsClient, TEST_TASK_ID);
+    QualityGateBreaker qualityGateBreaker = Mockito.spy(new QualityGateBreaker(null, fileSystem, settings));
+    Mockito.doReturn(taskResponse).when(qualityGateBreaker).getTask(wsResponse);
+    
+	qualityGateBreaker.getAnalysisId(wsClient, TEST_TASK_ID);
   }
 
   @Test
@@ -234,20 +239,21 @@ public final class QualityGateBreakerTest {
     WsClient wsClient = mock(WsClient.class);
     WsConnector wsConnector = mock(WsConnector.class);
     WsResponse wsResponse = mock(WsResponse.class);
-    // yuck
-    PowerMockito.mockStatic(TaskResponse.class);
+
     TaskResponse taskResponse = mock(TaskResponse.class);
     Task task = Task.newBuilder().setStatus(TaskStatus.CANCELED).build();
 
     when(wsClient.wsConnector()).thenReturn(wsConnector);
     when(wsConnector.call(any(WsRequest.class))).thenReturn(wsResponse);
-    when(TaskResponse.parseFrom(any(InputStream.class))).thenReturn(taskResponse);
     when(taskResponse.getTask()).thenReturn(task);
 
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("Report processing did not complete successfully: CANCELED");
 
-    new QualityGateBreaker(null, fileSystem, settings).getAnalysisId(wsClient, TEST_TASK_ID);
+    QualityGateBreaker qualityGateBreaker = Mockito.spy(new QualityGateBreaker(null, fileSystem, settings));
+    Mockito.doReturn(taskResponse).when(qualityGateBreaker).getTask(wsResponse);
+    
+	qualityGateBreaker.getAnalysisId(wsClient, TEST_TASK_ID);
   }
 
   @Test
@@ -260,19 +266,20 @@ public final class QualityGateBreakerTest {
     WsClient wsClient = mock(WsClient.class);
     WsConnector wsConnector = mock(WsConnector.class);
     WsResponse wsResponse = mock(WsResponse.class);
-    // yuck
-    PowerMockito.mockStatic(TaskResponse.class);
+    
     TaskResponse taskResponse = mock(TaskResponse.class);
     Task task =
         Task.newBuilder().setStatus(TaskStatus.SUCCESS).setAnalysisId(TEST_ANALYSIS_ID).build();
 
     when(wsClient.wsConnector()).thenReturn(wsConnector);
     when(wsConnector.call(any(WsRequest.class))).thenReturn(wsResponse);
-    when(TaskResponse.parseFrom(any(InputStream.class))).thenReturn(taskResponse);
     when(taskResponse.getTask()).thenReturn(task);
-
-    String analysisId =
-        new QualityGateBreaker(null, fileSystem, settings).getAnalysisId(wsClient, TEST_TASK_ID);
+    
+    QualityGateBreaker qualityGateBreaker = Mockito.spy(new QualityGateBreaker(null, fileSystem, settings));
+    Mockito.doReturn(taskResponse).when(qualityGateBreaker).getTask(wsResponse);
+    
+    String analysisId = qualityGateBreaker.getAnalysisId(wsClient, TEST_TASK_ID);
+    
     assertEquals(TEST_ANALYSIS_ID, analysisId);
   }
 
@@ -286,17 +293,17 @@ public final class QualityGateBreakerTest {
     WsClient wsClient = mock(WsClient.class);
     WsConnector wsConnector = mock(WsConnector.class);
     WsResponse wsResponse = mock(WsResponse.class);
-    // yuck
-    PowerMockito.mockStatic(TaskResponse.class);
 
     when(wsClient.wsConnector()).thenReturn(wsConnector);
     when(wsConnector.call(any(WsRequest.class))).thenReturn(wsResponse);
-    when(TaskResponse.parseFrom(any(InputStream.class))).thenThrow(new IOException());
 
     thrown.expect(IllegalStateException.class);
     thrown.expectCause(isA(IOException.class));
 
-    new QualityGateBreaker(null, fileSystem, settings).getAnalysisId(wsClient, TEST_TASK_ID);
+    QualityGateBreaker qualityGateBreaker = Mockito.spy(new QualityGateBreaker(null, fileSystem, settings));
+    Mockito.doThrow(new IOException()).when(qualityGateBreaker).getTask(wsResponse);
+    
+	qualityGateBreaker.getAnalysisId(wsClient, TEST_TASK_ID);
   }
 
   @Test

--- a/src/test/java/org/sonar/plugins/buildbreaker/QualityGateBreakerTest.java
+++ b/src/test/java/org/sonar/plugins/buildbreaker/QualityGateBreakerTest.java
@@ -148,6 +148,29 @@ public final class QualityGateBreakerTest {
     new QualityGateBreaker(analysisMode, fileSystem, settings).execute(null);
   }
 
+  /**
+   * This test follows the same pattern as {@link #testQueryMaxAttemptsReached()}, but with a different report
+   * file path.
+   */
+  @Test
+  public void testCustomReportFilePath() {
+    AnalysisMode analysisMode = mock(AnalysisMode.class);
+    when(analysisMode.isPublish()).thenReturn(true);
+
+    String reportFilePath = "/some/non/default/path/report-task.txt";
+    FileSystem fileSystem = mock(FileSystem.class);
+    when(fileSystem.resolvePath(reportFilePath))
+            .thenReturn(new File("src/test/resources/org/sonar/plugins/buildbreaker", "report-task.txt"));
+
+    Settings settings = new MapSettings();
+    settings.setProperty(QualityGateBreaker.SONAR_PROPERTY_METADATA_FILE_PATH, reportFilePath);
+
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Report processing is taking longer than the configured wait limit.");
+
+    new QualityGateBreaker(analysisMode, fileSystem, settings).execute(null);
+  }
+
   @Test
   public void testSingleQueryInProgressStatus() throws IOException {
     FileSystem fileSystem = mock(FileSystem.class);


### PR DESCRIPTION
Builds on #46.

Since SonarQube 7.2 this property exists to change the path of `report-task.txt`. Before this change, this file would always be read from the default directory, resulting in an `IllegalStateException` if `sonar.scanner.metadataFilePath` points to some other directory.

We ran into this since [this commit](https://github.com/SonarSource/sonar-scanner-vsts/commit/956ba211b6c7ecf40e50361fc941090707cb8847) in the Azure Pipelines Sonar extension, which fixed [this issue](https://jira.sonarsource.com/browse/VSTS-190).