### PR TITLE
Support sonar.scanner.metadataFilePath (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ SonarQube.
 
 Upon uploading the analysis information, the plugin follows the below workflow to check the quality gate:
 
-1. Search `${sonar.working.directory}/report-task.txt` for `ceTaskId`, the server-side Compute Engine (CE) task associated with the current analysis
+1. Search `${sonar.working.directory}/report-task.txt` for `ceTaskId`, the server-side Compute Engine (CE) task associated with the current analysis.
+    1. If the project configures `sonar.scanner.metadataFilePath`, that file is used instead of `${sonar.working.directory}/report-task.txt`
 2. Call the `${sonar.host.url}/api/ce/task?id=${ceTaskId}` web service to retrieve `analysisId`
-  1. If the CE Task Status is `PENDING` or `IN_PROGRESS`, wait `sonar.buildbreaker.queryInterval` and repeat step 2
-  2. If the CE Task Status is `SUCCESS`, save the `analysisId` and proceed to step 3
-  3. If the CE Task Status is `FAILED` or none of the above, break the build
-  4. If step 2 has been attempted `sonar.buildbreaker.queryMaxAttempts` times, break the build
+    1. If the CE Task Status is `PENDING` or `IN_PROGRESS`, wait `sonar.buildbreaker.queryInterval` and repeat step 2
+    2. If the CE Task Status is `SUCCESS`, save the `analysisId` and proceed to step 3
+    3. If the CE Task Status is `FAILED` or none of the above, break the build
+    4. If step 2 has been attempted `sonar.buildbreaker.queryMaxAttempts` times, break the build
 3. Call the `${sonar.host.url}/api/qualitygates/project_status?analysisId=${analysisId}` web service to check the status of the quality gate
-  1. If the quality gate status is `OK`, allow the build to pass
-  2. If the quality gate status is `WARN`, allow the build to pass and log the current warnings
-  3. If the quality gate status is `ERROR`, break the build and log the current warnings and errors
+    1. If the quality gate status is `OK`, allow the build to pass
+    2. If the quality gate status is `WARN`, allow the build to pass and log the current warnings
+    3. If the quality gate status is `ERROR`, break the build and log the current warnings and errors
 
 The build "break" is accomplished by throwing an exception, making the analysis return with a non-zero status code.
 This allows you to benefit from the notifications built into CI engines or use your own custom notifications that check the
@@ -50,10 +51,10 @@ exit status.
 
 1. Associate a quality gate to your project
 2. Optional: Tune `sonar.buildbreaker.queryMaxAttempts` and/or `sonar.buildbreaker.queryInterval`
-  1. Check the duration of previous CE (background) tasks for your project, from submission until completion
-  2. Ensure `sonar.buildbreaker.queryMaxAttempts * sonar.buildbreaker.queryInterval` is longer than the above duration (with default values, total wait time is ~5 minutes)
-  3. For small projects, a faster interval may be desired so your build times are not longer than necessary
-  4. For very large projects or servers with a busy CE queue, more attempts or a longer interval may be necessary
+    1. Check the duration of previous CE (background) tasks for your project, from submission until completion
+    2. Ensure `sonar.buildbreaker.queryMaxAttempts * sonar.buildbreaker.queryInterval` is longer than the above duration (with default values, total wait time is ~5 minutes)
+    3. For small projects, a faster interval may be desired so your build times are not longer than necessary
+    4. For very large projects or servers with a busy CE queue, more attempts or a longer interval may be necessary
 3. Run an analysis on your project
 4. If analysis fails while waiting for CE to complete, increase either `sonar.buildbreaker.queryMaxAttempts`, `sonar.buildbreaker.queryInterval`, or both
 
@@ -96,10 +97,10 @@ Pull requests are welcome, but may not always be reviewed immediately. We try ou
 1. This project uses [google-java-format](https://github.com/google/google-java-format). The code is auto-formatted whenever you build it.
 2. For the most part, the project follows standard Oracle Java code conventions
 3. Include unit tests
-   1. Do not use PowerMock unless there is no alternative
+    1. Do not use PowerMock unless there is no alternative
 4. Update the documentation (this `README.md`) with new configuration parameters and usage notes
 5. Make sure your change works with all versions of SonarQube starting at the minimum version
    defined in `pom.xml`
-   1. You can use the scripts in the `verification` folder to check compatibility. See the [verification/README.md](verification/README.md) for details.
-   2. If you need to upgrade the base SonarQube version, create an issue for discussion first
-   3. Once upgraded, the base version will not be downgraded
+    1. You can use the scripts in the `verification` folder to check compatibility. See the [verification/README.md](verification/README.md) for details.
+    2. If you need to upgrade the base SonarQube version, create an issue for discussion first
+    3. Once upgraded, the base version will not be downgraded

--- a/src/test/java/org/sonar/plugins/buildbreaker/QualityGateBreakerTest.java
+++ b/src/test/java/org/sonar/plugins/buildbreaker/QualityGateBreakerTest.java
@@ -21,17 +21,22 @@ package org.sonar.plugins.buildbreaker;
 
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Properties;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -65,9 +70,16 @@ public final class QualityGateBreakerTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
+  @Mock FileSystem fileSystem;
+
+  @Before
+  public void setup() {
+    when(fileSystem.workDir())
+        .thenReturn(new File("src/test/resources/org/sonar/plugins/buildbreaker"));
+  }
+
   @Test
   public void testShouldExecuteSuccess() {
-    FileSystem fileSystem = mock(FileSystem.class);
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.SKIP_KEY, false);
     Configuration config = new ConfigurationBridge(settings);
@@ -79,7 +91,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testShouldExecuteDisabledFromSkipSetting() {
-    FileSystem fileSystem = mock(FileSystem.class);
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.SKIP_KEY, true);
     Configuration config = new ConfigurationBridge(settings);
@@ -90,8 +101,29 @@ public final class QualityGateBreakerTest {
   }
 
   @Test
+  public void testLoadReportTaskTxtFile() {
+    Settings settings = new MapSettings();
+    Configuration config = new ConfigurationBridge(settings);
+
+    Properties reportTaskProps = new QualityGateBreaker(fileSystem, config).loadReportTaskProps();
+    assertEquals("AVKJ_h9DIK5ABR5tIoQ_", reportTaskProps.getProperty("ceTaskId"));
+  }
+
+  @Test
+  public void testLoadReportTaskTxtFileFromMetadataFilePath() {
+    Settings settings = new MapSettings();
+    settings.setProperty(
+        QualityGateBreaker.METADATA_FILE_PATH_KEY,
+        "src/test/resources/org/sonar/plugins/buildbreaker/alternative-report-task.txt");
+    Configuration config = new ConfigurationBridge(settings);
+
+    Properties reportTaskProps = new QualityGateBreaker(fileSystem, config).loadReportTaskProps();
+    assertEquals("AXBTzuDyxOk5_RWMXCjJ", reportTaskProps.getProperty("ceTaskId"));
+  }
+
+  @Test
   public void testNoReportTaskTxtFile() {
-    FileSystem fileSystem = mock(FileSystem.class);
+    when(fileSystem.workDir()).thenReturn(new File("src/test/resources"));
     Settings settings = new MapSettings();
     Configuration config = new ConfigurationBridge(settings);
 
@@ -108,10 +140,6 @@ public final class QualityGateBreakerTest {
    */
   @Test
   public void testQueryMaxAttemptsReached() {
-    FileSystem fileSystem = mock(FileSystem.class);
-    when(fileSystem.workDir())
-        .thenReturn(new File("src/test/resources/org/sonar/plugins/buildbreaker"));
-
     Settings settings = new MapSettings();
     Configuration config = new ConfigurationBridge(settings);
 
@@ -123,8 +151,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testSingleQueryInProgressStatus() throws IOException {
-    FileSystem fileSystem = mock(FileSystem.class);
-
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.QUERY_MAX_ATTEMPTS_KEY, 1);
     Configuration config = new ConfigurationBridge(settings);
@@ -150,8 +176,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testSingleQueryPendingStatus() throws IOException {
-    FileSystem fileSystem = mock(FileSystem.class);
-
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.QUERY_MAX_ATTEMPTS_KEY, 1);
     Configuration config = new ConfigurationBridge(settings);
@@ -177,8 +201,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testSingleQueryFailedStatus() throws IOException {
-    FileSystem fileSystem = mock(FileSystem.class);
-
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.QUERY_MAX_ATTEMPTS_KEY, 1);
     Configuration config = new ConfigurationBridge(settings);
@@ -204,8 +226,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testSingleQueryCanceledStatus() throws IOException {
-    FileSystem fileSystem = mock(FileSystem.class);
-
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.QUERY_MAX_ATTEMPTS_KEY, 1);
     Configuration config = new ConfigurationBridge(settings);
@@ -231,8 +251,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testSingleQuerySuccessStatus() throws IOException {
-    FileSystem fileSystem = mock(FileSystem.class);
-
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.QUERY_MAX_ATTEMPTS_KEY, 1);
     Configuration config = new ConfigurationBridge(settings);
@@ -258,8 +276,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testSingleQueryIOException() throws IOException {
-    FileSystem fileSystem = mock(FileSystem.class);
-
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.QUERY_MAX_ATTEMPTS_KEY, 1);
     Configuration config = new ConfigurationBridge(settings);
@@ -282,8 +298,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testQualityGateStatusWarning() {
-    FileSystem fileSystem = mock(FileSystem.class);
-
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.QUERY_MAX_ATTEMPTS_KEY, 1);
     Configuration config = new ConfigurationBridge(settings);
@@ -305,8 +319,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testQualityGateStatusError() {
-    FileSystem fileSystem = mock(FileSystem.class);
-
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.QUERY_MAX_ATTEMPTS_KEY, 1);
     Configuration config = new ConfigurationBridge(settings);
@@ -329,8 +341,6 @@ public final class QualityGateBreakerTest {
 
   @Test
   public void testQualityGateStatusOk() {
-    FileSystem fileSystem = mock(FileSystem.class);
-
     Settings settings = new MapSettings();
     settings.setProperty(BuildBreakerPlugin.QUERY_MAX_ATTEMPTS_KEY, 1);
     Configuration config = new ConfigurationBridge(settings);

--- a/src/test/resources/org/sonar/plugins/buildbreaker/alternative-report-task.txt
+++ b/src/test/resources/org/sonar/plugins/buildbreaker/alternative-report-task.txt
@@ -1,0 +1,5 @@
+projectKey=group:artifact:branch
+serverUrl=http://example.com:9000
+dashboardUrl=http://example.com:9000/dashboard/index/group:artifact:branch
+ceTaskId=AXBTzuDyxOk5_RWMXCjJ
+ceTaskUrl=http://example.com:9000/api/ce/task?id=AVKJ_h9DIK5ABR5tIoQ_


### PR DESCRIPTION
Build breaker now reads the file from sonar.scanner.metadataFilePath, if set,
instead of the default report-task.txt file.

Also fixed indentation of nested lists in README.